### PR TITLE
Update metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@aws-sdk/client-cloudwatch": "^3.490.0",
         "commander": "^11.1.0"
       },
+      "bin": {
+        "deployment-stats": "build/index.js"
+      },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.3",
         "@typescript-eslint/eslint-plugin": "^6.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.3",
+        "@types/node": "^20.11.13",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
         "eslint": "^8.56.0",
@@ -1499,6 +1500,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.13.tgz",
+      "integrity": "sha512-5G4zQwdiQBSWYTDAH1ctw2eidqdhMJaNsiIDKHFr55ihz5Trl2qqR8fdrT732yPBho5gkNxXm67OxWFBqX9aPg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -4177,6 +4187,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/cuckoointernet/logger-nodejs#readme",
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.3",
+    "@types/node": "^20.11.13",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",
     "eslint": "^8.56.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ program
   .argument("<project>")
   .option("-s, --status <status>")
   .option("-e, --environment <environment>")
+  .option("-d --deploy-duration <deploy-duration>")
   .action(async (project, options) => {
     const input: PutMetricDataCommandInput = {
       MetricData: [
@@ -25,6 +26,27 @@ program
           Dimensions: [
             { Name: "Environment", Value: options.environment },
             { Name: "Project", Value: project },
+            { Name: "DeployDuration", Value: options.deployDuration },
+          ],
+          Unit: "Count",
+          Value: 1,
+        },
+        {
+          MetricName: `deployment.${options.status}`,
+          Dimensions: [{ Name: "Environment", Value: options.environment }],
+          Unit: "Count",
+          Value: 1,
+        },
+        {
+          MetricName: `deployment.${options.status}`,
+          Dimensions: [{ Name: "Project", Value: project }],
+          Unit: "Count",
+          Value: 1,
+        },
+        {
+          MetricName: `deployment.${options.status}`,
+          Dimensions: [
+            { Name: "DeployDuration", Value: options.deployDuration },
           ],
           Unit: "Count",
           Value: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,6 @@ program
             Dimensions: [
               { Name: "Environment", Value: options.environment },
               { Name: "Project", Value: project },
-              { Name: "Status", Value: options.status },
             ],
             Unit: "Count",
             Value: 1,
@@ -52,12 +51,6 @@ program
           {
             MetricName: `deployment.${options.status}`,
             Dimensions: [{ Name: "Project", Value: project }],
-            Unit: "Count",
-            Value: 1,
-          },
-          {
-            MetricName: `deployment.${options.status}`,
-            Dimensions: [{ Name: "Status", Value: options.status }],
             Unit: "Count",
             Value: 1,
           },
@@ -99,8 +92,10 @@ program
 
       await client.send(new PutMetricDataCommand(input));
       console.log("Deployment metrics published to CloudWatch");
+      process.exit(0);
     } catch (error) {
       console.error("Error sending metrics to CloudWatch:", error);
+      process.exit(1);
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,14 +43,6 @@ program
           Unit: "Count",
           Value: 1,
         },
-        {
-          MetricName: `deployment.${options.status}`,
-          Dimensions: [
-            { Name: "DeployDuration", Value: options.deployDuration },
-          ],
-          Unit: "Count",
-          Value: 1,
-        },
       ],
       Namespace: "cuckoo",
     };


### PR DESCRIPTION
## Background

We want better visibility over how long deployments take. This PR adds the option `--deploy-duration` or `-d` which will then be included in the metrics sent to Cloudwatch.

It also adds separate metrics for `environment` and `project` (so we can query them individually).